### PR TITLE
Enable read_concurrency for down_replicas

### DIFF
--- a/lib/phoenix/tracker/state.ex
+++ b/lib/phoenix/tracker/state.ex
@@ -65,7 +65,10 @@ defmodule Phoenix.Tracker.State do
       values: :ets.new(shard_name, [:named_table, :protected, :ordered_set]),
       pids: :ets.new(:pids, [:duplicate_bag]),
       tags: :ets.new(:tags, [:set]),
-      down_replicas: :ets.new(down_replicas_table(shard_name), [:named_table, :protected, :bag])})
+      down_replicas: :ets.new(
+        down_replicas_table(shard_name),
+        [:named_table, :protected, :bag, {:read_concurrency, true}]
+      )})
   end
 
   @doc """


### PR DESCRIPTION
https://erlang.org/doc/man/ets.html

> Performance tuning. Defaults to false. When set to true, the table is
optimized for concurrent read operations. When this option is enabled on
a runtime system with SMP support, read operations become much cheaper;
especially on systems with multiple physical processors. However,
switching between read and write operations becomes more expensive.

We have a lot of read operations. Each time get_by_key or get_by_topic
is called then this table is read. We want it to be as fast as possible.

> You typically want to enable this option when concurrent read
operations are much more frequent than write operations, or when
concurrent reads and writes comes in large read and write bursts (that
is, many reads not interrupted by writes, and many writes not
interrupted by reads).

This table is rarely updated. It is only updated when a replica goes
down or when that replica comes back up.